### PR TITLE
Allow projects to enable/disable as needed

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -7,6 +7,8 @@ Redmine::Plugin.register :msproject_import do
   author_url 'https://github.com/braini75'
   
   settings :default => {'tracker_default' => 2}, :partial => 'settings/msproject_import'
-  permission :msproject_import, { :msproj_imp => [:upload, :import, :analyze, :import_results]}
+  project_module msproject_import do
+    permission :msproject_import, { :msproj_imp => [:upload, :import, :analyze, :import_results]}
+  end
   menu :project_menu, :msproject_import, { :controller => 'msproj_imp', :action => 'upload' }, :caption => :menu_caption, :after => :settings, :param => :project_id  
 end


### PR DESCRIPTION
Makes the plugin a module plugin. Thus managers can go in and enable/disable this functionality as needed.
